### PR TITLE
Avoiding a page to be sent 2 times

### DIFF
--- a/views/templates/hook/ps_googleanalytics.tpl
+++ b/views/templates/hook/ps_googleanalytics.tpl
@@ -53,8 +53,6 @@
     {/if}
     {if $backOffice}
         ga('set', 'nonInteraction', true);
-    {else}
-        ga('send', 'pageview');
     {/if}
 {literal}
     ga('require', 'ec');


### PR DESCRIPTION
Each page is sent two times to Google Analytics because of the instruction on the front office:
> ga('send', 'pageview');

Now it seems to be ok