### PR TITLE
Add tracking of cancelled orders

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_googleanalytics</name>
 	<displayName><![CDATA[Google Analytics]]></displayName>
-	<version><![CDATA[3.2.0]]></version>
+	<version><![CDATA[3.3.0]]></version>
 	<description><![CDATA[Gain clear insights into important metrics about your customers, using Google Analytics]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -77,6 +77,7 @@ class Ps_Googleanalytics extends Module
             $this->registerHook('actionProductCancel') &&
             $this->registerHook('actionCartSave') &&
             $this->registerHook('displayBackOfficeHeader') &&
+	    $this->registerHook('hookactionOrderStatusPostUpdate') &&
             $this->registerHook('actionCarrierProcess')
         ) {
             return $this->createTables();
@@ -844,6 +845,20 @@ class Ps_Googleanalytics extends Module
             return $js.$this->hookdisplayHeader(null, true).$this->_runJs($ga_scripts, 1);
         } else {
             return $js;
+        }
+    }
+
+    /**
+     * Hook called after order status change
+     * Used to cancel order after cancelling it
+     */
+    public function hookactionOrderStatusPostUpdate($params)
+    {
+        $order_status = $params['newOrderStatus']->id;
+
+        // If we have the order and new order status in CANCELED
+        if (!empty($params['id_order']) && !empty($order_status) && $order_status == (int) Configuration::get('PS_OS_CANCELED')) {
+            $this->context->cookie->ga_admin_refund = $ga_scripts . 'MBG.refundByOrderId(' . json_encode(['id' => $params['id_order']]) . ');';
         }
     }
 

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -873,7 +873,7 @@ class Ps_Googleanalytics extends Module
             $this->context->cookie->ga_admin_refund = $ga_scripts . 'MBG.refundByOrderId(' . json_encode(['id' => $params['id_order']]) . ');';
             Db::getInstance()->execute(
                 'UPDATE `'._DB_PREFIX_.'ganalytics` SET refund_sent = 1 WHERE id_order = '. (int) $params['id_order']
-	    );
+            );
         }
 
     }

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -77,7 +77,7 @@ class Ps_Googleanalytics extends Module
             $this->registerHook('actionProductCancel') &&
             $this->registerHook('actionCartSave') &&
             $this->registerHook('displayBackOfficeHeader') &&
-	    $this->registerHook('hookactionOrderStatusPostUpdate') &&
+            $this->registerHook('hookactionOrderStatusPostUpdate') &&
             $this->registerHook('actionCarrierProcess')
         ) {
             return $this->createTables();
@@ -852,12 +852,10 @@ class Ps_Googleanalytics extends Module
      * Hook called after order status change
      * Used to cancel order after cancelling it
      */
-    public function hookactionOrderStatusPostUpdate($params)
+    public function hookactionOrderStatusPostUpdate(array $params)
     {
-        $order_status = $params['newOrderStatus']->id;
-
-        // If we have the order and new order status in CANCELED
-        if (!empty($params['id_order']) && !empty($order_status) && $order_status == (int) Configuration::get('PS_OS_CANCELED')) {
+        // If we have the order AND the new order status being set AND the order status is changing to CANCELLED
+        if (!empty($params['id_order']) && !empty($params['newOrderStatus']->id) && $params['newOrderStatus']->id == (int) Configuration::get('PS_OS_CANCELED')) {
             $this->context->cookie->ga_admin_refund = $ga_scripts . 'MBG.refundByOrderId(' . json_encode(['id' => $params['id_order']]) . ');';
         }
     }

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -131,6 +131,7 @@ class Ps_Googleanalytics extends Module
 				`id_customer` int(10) NOT NULL,
 				`id_shop` int(11) NOT NULL,
 				`sent` tinyint(1) DEFAULT NULL,
+				`refund_sent` tinyint(1) DEFAULT NULL,
 				`date_add` datetime DEFAULT NULL,
 				PRIMARY KEY (`id_google_analytics`),
 				KEY `id_order` (`id_order`),

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -870,7 +870,7 @@ class Ps_Googleanalytics extends Module
             
         if ($gaRefundSent === false) {
             // We refund it and set the "sent" flag to true
-            $this->context->cookie->ga_admin_refund = $ga_scripts . 'MBG.refundByOrderId(' . json_encode(['id' => $params['id_order']]) . ');';
+            $this->context->cookie->ga_admin_refund = 'MBG.refundByOrderId(' . json_encode(['id' => $params['id_order']]) . ');';
             Db::getInstance()->execute(
                 'UPDATE `'._DB_PREFIX_.'ganalytics` SET refund_sent = 1 WHERE id_order = '. (int) $params['id_order']
             );

--- a/upgrade/upgrade-3.3.0.php
+++ b/upgrade/upgrade-3.3.0.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * 2007-2020 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_3_3_0($object)
+{
+    if ($object->registerHook('actionOrderStatusPostUpdate') == false) {
+        return false;
+    }
+    
+    return Db::getInstance()->execute('ALTER TABLE `'._DB_PREFIX_.'ganalytics` ADD `refund_sent` tinyint(1) NULL AFTER `sent`;');
+}


### PR DESCRIPTION
This PR enables tracking of cancelled orders, which could greatly affect the statistics. The refund functionality is already provided by the enhanced ecommerce library.

**Changes**
- The functionality hooks to actionOrderStatusPostUpdate.
- The functionality adds 1 column to ps_ganalytics to prevent multiple refunds for one order.
- Bumps module version to 3.3.0 to run the upgrade script needed.

**How it works**
- After you change the order status, the module checks, if the new status is CANCELLED.
- If so, it checks the database, if this order was not cancelled before - to prevent multiple refunds, which Google Analytics unfortunately allows.
- If no refund information found in database, adds the refund action by MBG.refundByOrderId.

**How to test**
1. Install Google Tag Assistant (in Chrome).
2. Install this module, set it up.
3. Make an order, go to it's administration.
4. Enable recording in Google Tag Assistant.
5. Change order status to cancelled.
6. After page refresh, check Google Tag Assistant and see the Refund event being sent.
(After some hours, the transaction will disappear from Google Analytics.)
7. Change order status to "Processing", then, change it back to "Cancelled".
8. No refund event should be sent.