### PR TITLE
Avoid array to string error on homepage with cart

### DIFF
--- a/classes/Hook/HookDisplayFooter.php
+++ b/classes/Hook/HookDisplayFooter.php
@@ -28,6 +28,8 @@ use PrestaShop\Module\Ps_Googleanalytics\Handler\GanalyticsJsHandler;
 use PrestaShop\Module\Ps_Googleanalytics\Wrapper\ProductWrapper;
 use Ps_Googleanalytics;
 use Tools;
+use RecursiveIteratorIterator;
+use RecursiveArrayIterator;
 
 class HookDisplayFooter implements HookInterface
 {
@@ -69,6 +71,11 @@ class HookDisplayFooter implements HookInterface
                     } elseif ($gacart['quantity'] < 0) {
                         $gacart['quantity'] = abs($gacart['quantity']);
                         $gaScripts .= 'MBG.removeFromCart(' . json_encode($gacart) . ');';
+                    }
+                } elseif (is_array($gacart)) {
+                    $it = new RecursiveIteratorIterator(new RecursiveArrayIterator($gacart));
+                    foreach($it as $v) {
+                      $gaScripts .= $v;
                     }
                 } else {
                     $gaScripts .= $gacart;

--- a/classes/Hook/HookDisplayFooter.php
+++ b/classes/Hook/HookDisplayFooter.php
@@ -27,9 +27,9 @@ use PrestaShop\Module\Ps_Googleanalytics\Handler\GanalyticsDataHandler;
 use PrestaShop\Module\Ps_Googleanalytics\Handler\GanalyticsJsHandler;
 use PrestaShop\Module\Ps_Googleanalytics\Wrapper\ProductWrapper;
 use Ps_Googleanalytics;
-use Tools;
-use RecursiveIteratorIterator;
 use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
+use Tools;
 
 class HookDisplayFooter implements HookInterface
 {
@@ -74,8 +74,8 @@ class HookDisplayFooter implements HookInterface
                     }
                 } elseif (is_array($gacart)) {
                     $it = new RecursiveIteratorIterator(new RecursiveArrayIterator($gacart));
-                    foreach($it as $v) {
-                      $gaScripts .= $v;
+                    foreach ($it as $v) {
+                        $gaScripts .= $v;
                     }
                 } else {
                     $gaScripts .= $gacart;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The module generates a multilevel array at the single-page checkout. This provokes an array to string casting error.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_googleanalytics/issues/60
| How to test?  | Enable debug mode and use the single-page checkout with a new user. Before the payment method is reached, you will see the array to string error.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
