### PR TITLE
Fix logic, avoid double pageview for BO pages

### DIFF
--- a/classes/Hook/HookDisplayHeader.php
+++ b/classes/Hook/HookDisplayHeader.php
@@ -31,6 +31,10 @@ class HookDisplayHeader implements HookInterface
     private $module;
     private $context;
     private $params;
+
+    /**
+     * @var bool
+     */
     private $backOffice;
 
     public function __construct(Ps_Googleanalytics $module, Context $context)
@@ -100,12 +104,18 @@ class HookDisplayHeader implements HookInterface
     }
 
     /**
-     * setBackOffice
-     *
-     * @param array $backOffice
+     * @param bool $backOffice
      */
     public function setBackOffice($backOffice)
     {
-        $this->module->backOffice = $backOffice;
+        $this->acknowledgeBackOfficeContext($backOffice);
+    }
+
+    /**
+     * @param bool $isBackOffice
+     */
+    public function acknowledgeBackOfficeContext($isBackOffice)
+    {
+        $this->backOffice = $isBackOffice;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We got reports that the v4.0.0 of the module does send double pageviews to GA. I checked the code and found that, because of a bad variable assignment, the context of HookDisplayHeade was not correctly set. I fixed that, which should resume expected behavior for the module = pageview event only sent once. See changed files for more detail.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_googleanalytics/issues/61 and probably https://github.com/PrestaShop/ps_googleanalytics/issues/64
| How to test?  | See below

## How to test ?

### See error

1. Install module, set it up with Google Analytics account.
2. Open a BO page, and you can see the number of pageviews is x2 . If you open the page 3 times you can see 6 pageviews.

### See fix

3. Test the module with this PR. The pageviews number is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
