### PR TITLE
Handle NOW correctly when creating order and register in SQL

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -41,7 +41,7 @@ class ps_GoogleanalyticsAjaxModuleFrontController extends ModuleFrontController
         (new GanalyticsRepository())->updateData(
             [
                 'sent' => 1,
-                'date_add' => 'NOW()',
+                'date_add' => ['value' => 'NOW()', 'type' => 'sql'],
             ],
             'id_order = ' . $orderId,
             1


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When placing an order, the timestamp data was badly registered in MySQL (0000-00-00 00:00:00 instead of current datetime) inside `ps_ganalytics` table. It's because `NOW()` is specific value and must be configured as such, else PrestaShop considers it's the string `NOW()` and not the operator.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_googleanalytics/issues/62
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
