### PR TITLE
Add Configuration option to disable Back Office tracking

### DIFF
--- a/classes/Form/ConfigurationForm.php
+++ b/classes/Form/ConfigurationForm.php
@@ -127,6 +127,24 @@ class ConfigurationForm
                         ],
                     ],
                 ],
+                [
+                    'type' => 'switch',
+                    'label' => $this->module->l('Disable Back Office Tracking'),
+                    'name' => 'GA_TRACK_BACKOFFICE_DISABLED',
+                    'hint' => $this->module->l('Use this option to disable the tracking inside the Back Office'),
+                    'values' => [
+                        [
+                            'id' => 'ga_track_backoffice',
+                            'value' => 1,
+                            'label' => $this->module->l('Enabled'),
+                        ],
+                        [
+                            'id' => 'ga_do_not_track_backoffice',
+                            'value' => 0,
+                            'label' => $this->module->l('Disabled'),
+                        ],
+                    ],
+                ],
             ],
             'submit' => [
                 'title' => $this->module->l('Save'),
@@ -158,6 +176,7 @@ class ConfigurationForm
         $helper->fields_value['GA_USERID_ENABLED'] = Configuration::get('GA_USERID_ENABLED');
         $helper->fields_value['GA_CROSSDOMAIN_ENABLED'] = Configuration::get('GA_CROSSDOMAIN_ENABLED');
         $helper->fields_value['GA_ANONYMIZE_ENABLED'] = Configuration::get('GA_ANONYMIZE_ENABLED');
+        $helper->fields_value['GA_TRACK_BACKOFFICE_DISABLED'] = Configuration::get('GA_TRACK_BACKOFFICE_DISABLED');
 
         return $helper->generateForm($fields_form);
     }
@@ -174,6 +193,7 @@ class ConfigurationForm
         $gaUserIdEnabled = Tools::getValue('GA_USERID_ENABLED');
         $gaCrossdomainEnabled = Tools::getValue('GA_CROSSDOMAIN_ENABLED');
         $gaAnonymizeEnabled = Tools::getValue('GA_ANONYMIZE_ENABLED');
+        $gaTrackBackOffice = Tools::getValue('GA_TRACK_BACKOFFICE_DISABLED');
 
         if (!empty($gaAccountId)) {
             Configuration::updateValue('GA_ACCOUNT_ID', $gaAccountId);
@@ -194,6 +214,11 @@ class ConfigurationForm
         if (null !== $gaAnonymizeEnabled) {
             Configuration::updateValue('GA_ANONYMIZE_ENABLED', (bool) $gaAnonymizeEnabled);
             $treatmentResult .= $this->module->displayConfirmation($this->module->l('Settings for Anonymize IP updated successfully'));
+        }
+
+        if (null !== $gaTrackBackOffice) {
+            Configuration::updateValue('GA_TRACK_BACKOFFICE_DISABLED', (bool) $gaTrackBackOffice);
+            $treatmentResult .= $this->module->displayConfirmation($this->module->l('Settings for Disable Back Office tracking updated successfully'));
         }
 
         return $treatmentResult;

--- a/classes/Hook/HookDisplayBackOfficeHeader.php
+++ b/classes/Hook/HookDisplayBackOfficeHeader.php
@@ -49,7 +49,7 @@ class HookDisplayBackOfficeHeader implements HookInterface
     public function run()
     {
         if (Configuration::get('GA_TRACK_BACKOFFICE_DISABLED')) {
-            return;
+            return '';
         }
 
         $js = '';

--- a/classes/Hook/HookDisplayBackOfficeHeader.php
+++ b/classes/Hook/HookDisplayBackOfficeHeader.php
@@ -48,6 +48,10 @@ class HookDisplayBackOfficeHeader implements HookInterface
      */
     public function run()
     {
+        if (Configuration::get('GA_TRACK_BACKOFFICE_DISABLED')) {
+            return;
+        }
+
         $js = '';
         if (strcmp(Tools::getValue('configure'), $this->module->name) === 0) {
             $this->context->controller->addCSS($this->module->getPathUri() . 'views/css/ganalytics.css');

--- a/classes/Hook/HookDisplayHeader.php
+++ b/classes/Hook/HookDisplayHeader.php
@@ -50,6 +50,10 @@ class HookDisplayHeader implements HookInterface
             return;
         }
 
+        if (Configuration::get('GA_TRACK_BACKOFFICE_DISABLED') && $this->backOffice) {
+            return;
+        }
+
         $this->context->controller->addJs($this->module->getPathUri() . 'views/js/GoogleAnalyticActionLib.js');
 
         $shops = Shop::getShops();

--- a/classes/Hook/HookDisplayHeader.php
+++ b/classes/Hook/HookDisplayHeader.php
@@ -47,11 +47,11 @@ class HookDisplayHeader implements HookInterface
     public function run()
     {
         if (!Configuration::get('GA_ACCOUNT_ID')) {
-            return;
+            return '';
         }
 
         if (Configuration::get('GA_TRACK_BACKOFFICE_DISABLED') && $this->backOffice) {
-            return;
+            return '';
         }
 
         $this->context->controller->addJs($this->module->getPathUri() . 'views/js/GoogleAnalyticActionLib.js');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add an option inside Configure page to disable Back Office tracking
| Type?         | new feature
| BC breaks | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_googleanalytics/issues/71
| How to test?  | Open module, see the new option. Please check that when used (= disable BO tracking), no data is sent to Google from BO pages.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
