### PR TITLE
Avoid force hooking of ps_featuredproducts on displayHome hook

### DIFF
--- a/classes/Handler/ModuleHandler.php
+++ b/classes/Handler/ModuleHandler.php
@@ -25,8 +25,6 @@ use Module;
 class ModuleHandler
 {
     /**
-     * isModuleEnabled
-     *
      * @param string $moduleName
      *
      * @return bool
@@ -47,12 +45,27 @@ class ModuleHandler
             return false;
         }
 
-        return $module->registerHook('displayHome');
+        return true;
     }
 
     /**
-     * uninstallModule
+     * @param string $moduleName
+     * @param string $hookName
      *
+     * @return bool
+     */
+    public function isModuleEnabledAndHookedOn($moduleName, $hookName)
+    {
+        $module = Module::getInstanceByName($moduleName);
+
+        if (false === $this->isModuleEnabled($moduleName)) {
+            return false;
+        }
+
+        return $module->isRegisteredInHook($hookName);
+    }
+
+    /**
      * @param string $moduleName
      *
      * @return bool

--- a/classes/Hook/HookDisplayHome.php
+++ b/classes/Hook/HookDisplayHome.php
@@ -53,7 +53,7 @@ class HookDisplayHome implements HookInterface
         $gaScripts = '';
 
         // Home featured products
-        if ($moduleHandler->isModuleEnabled('ps_featuredproducts')) {
+        if ($moduleHandler->isModuleEnabledAndHookedOn('ps_featuredproducts', 'displayHome')) {
             $category = new Category($this->context->shop->getCategory(), $this->context->language->id);
             $productWrapper = new ProductWrapper($this->context);
             $homeFeaturedProducts = $productWrapper->wrapProductList(


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As described in https://github.com/PrestaShop/ps_googleanalytics/issues/33, current implementation forces the hook of module `ps_featuredproducts` to hook `displayHome` when used on Homepage. I fix this.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_googleanalytics/issues/33
| How to test?  | See below

## How to test

### Current implementation

In current implementation, if you un-hook module ps_featuredproducts from displayHome hook THEN you enable ps_googleanalytics module, the ps_googleanalytics _forces_ module ps_featuredproducts to be hooked on displayHome hook

### New implementation (in the PR)

In the PR I make sure we do not force the hook.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
