### PR TITLE
Fix double and triple pageview requests

### DIFF
--- a/views/templates/hook/ga_tag.tpl
+++ b/views/templates/hook/ga_tag.tpl
@@ -28,11 +28,3 @@
     </script>
     {/literal}
 {/if}
-
-{if ($jsState != 1 && $isBackoffice === true)}
-    {literal}
-    <script type="text/javascript">
-        ga('send', 'pageview');
-    </script>
-    {/literal}
-{/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is an useless code that only outputs extra pageviews to the page. Pageview is always sent from header hook (ps_googleanalytics.tpl).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/ps_googleanalytics/issues/64 https://github.com/PrestaShop/ps_googleanalytics/issues/61
| How to test?  | Install Google Tag Assistant. Open any order in BO, open any page in FO. Enable assistant. Refresh page. Only 1 pageview will be sent.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
