### PR TITLE
Update HookDisplayOrderConfirmation.php

### DIFF
--- a/classes/Hook/HookDisplayOrderConfirmation.php
+++ b/classes/Hook/HookDisplayOrderConfirmation.php
@@ -66,7 +66,7 @@ class HookDisplayOrderConfirmation implements HookInterface
                         'id_order' => (int) $order->id,
                         'id_shop' => (int) $this->context->shop->id,
                         'sent' => 0,
-                        'date_add' => 'NOW()',
+                        'date_add' => ['value' => 'NOW()', 'type' => 'sql'],
                     ]
                 );
 


### PR DESCRIPTION
Fixes #62

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When placing an order, the timestamp data was badly registered in MySQL (0000-00-00 00:00:00 instead of current datetime) inside ps_ganalytics table. It's because NOW() is specific value and must be configured as such, else PrestaShop considers it's the string NOW() and not the operator.
| Type?         | bug fix
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | #62
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
