### PR TITLE
Prevent error when GoogleAnalyticEnhancedECommerce is not set

### DIFF
--- a/views/templates/hook/ga_tag.tpl
+++ b/views/templates/hook/ga_tag.tpl
@@ -21,9 +21,11 @@
     {literal}
     <script type="text/javascript">
         document.addEventListener('DOMContentLoaded', function() {
-            var MBG = GoogleAnalyticEnhancedECommerce;
-            MBG.setCurrency('{/literal}{$isoCode|escape:'htmlall':'UTF-8'}{literal}');
-            {/literal}{$jsCode nofilter}{literal}
+            if (typeof GoogleAnalyticEnhancedECommerce !== 'undefined') {
+                var MBG = GoogleAnalyticEnhancedECommerce;
+                MBG.setCurrency('{/literal}{$isoCode|escape:'htmlall':'UTF-8'}{literal}');
+                {/literal}{$jsCode nofilter}{literal}
+            }
         });
     </script>
     {/literal}


### PR DESCRIPTION
In some case GoogleAnalyticEnhancedECommerce is not set.
To prevent any javascript error as ```Uncaught ReferenceError: GoogleAnalyticEnhancedECommerce is not defined``` provide a test before to use it

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Prevent Uncaught ReferenceError and block javascript execution
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     |  Fixes https://github.com/PrestaShop/PrestaShop/issues/26093
| How to test?      | 
| Possible impacts? | Any

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
