### PR TITLE
Check if array key products exists before using it

### DIFF
--- a/classes/Hook/HookDisplayFooter.php
+++ b/classes/Hook/HookDisplayFooter.php
@@ -87,7 +87,7 @@ class HookDisplayFooter implements HookInterface
 
         $listing = $this->context->smarty->getTemplateVars('listing');
         $productWrapper = new ProductWrapper($this->context);
-        $products = $productWrapper->wrapProductList($listing['products'], [], true);
+        $products = $productWrapper->wrapProductList(isset($listing['products']) ? $listing['products'] : [], [], true);
 
         if ($controller_name == 'order' || $controller_name == 'orderopc') {
             $this->module->js_state = 1;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | An array key not always available was access without checking if it actually exists, leading to an exception in php >= 7.4. This PR fixes by checking it and returning an empty array if it doesn't exist.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#26539
| How to test?      | Please see PrestaShop/PrestaShop#26539
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
