### PR TITLE
Fix hook actionProductCancel call & Bump version to 4.1.2

### DIFF
--- a/classes/Hook/HookActionProductCancel.php
+++ b/classes/Hook/HookActionProductCancel.php
@@ -23,7 +23,6 @@ namespace PrestaShop\Module\Ps_Googleanalytics\Hooks;
 use Context;
 use OrderDetail;
 use Ps_Googleanalytics;
-use Tools;
 
 class HookActionProductCancel implements HookInterface
 {
@@ -44,19 +43,18 @@ class HookActionProductCancel implements HookInterface
      */
     public function run()
     {
-        $quantityRefunded = Tools::getValue('cancelQuantity');
-        $gaScripts = '';
-
-        foreach ($quantityRefunded as $orderDetailId => $quantity) {
-            // Display GA refund product
-            $orderDetail = new OrderDetail($orderDetailId);
-            $gaScripts .= 'MBG.add(' . json_encode(
-                [
-                    'id' => empty($orderDetail->product_attribute_id) ? $orderDetail->product_id : $orderDetail->product_id . '-' . $orderDetail->product_attribute_id,
-                    'quantity' => $quantity,
-                ])
-                . ');';
+        if (!isset($this->params['id_order_detail']) || !isset($this->params['cancel_quantity'])) {
+            return;
         }
+
+        // Display GA refund product
+        $orderDetail = new OrderDetail($this->params['id_order_detail']);
+        $gaScripts = 'MBG.add(' . json_encode(
+            [
+                'id' => empty($orderDetail->product_attribute_id) ? $orderDetail->product_id : $orderDetail->product_id . '-' . $orderDetail->product_attribute_id,
+                'quantity' => $this->params['cancel_quantity'],
+            ])
+            . ');';
 
         $this->context->cookie->__set(
             'ga_admin_refund',

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_googleanalytics</name>
 	<displayName><![CDATA[Google Analytics]]></displayName>
-	<version><![CDATA[4.1.1]]></version>
+	<version><![CDATA[4.1.2]]></version>
 	<description><![CDATA[Gain clear insights into important metrics about your customers, using Google Analytics]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/ps_googleanalytics.php
+++ b/ps_googleanalytics.php
@@ -54,7 +54,7 @@ class Ps_Googleanalytics extends Module
     {
         $this->name = 'ps_googleanalytics';
         $this->tab = 'analytics_stats';
-        $this->version = '4.1.1';
+        $this->version = '4.1.2';
         $this->ps_versions_compliancy = ['min' => '1.6', 'max' => _PS_VERSION_];
         $this->author = 'PrestaShop';
         $this->module_key = 'fd2aaefea84ac1bb512e6f1878d990b8';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix hook actionProductCancel call & Bump version to 4.1.2
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Relative to PrestaShop/PrestaShop#27911 & Fixes PrestaShop/PrestaShop#26098
| How to test?      | The cancelling of a product executes an hook but with 4.1.1 version, the hook has problems detected with Behat Tests (https://github.com/PrestaShop/PrestaShop/runs/5657683377?check_suite_focus=true#step:17:239). (And Release Test).<br><br>For testing :<br>* Install the module in version 4.1.1<br>* Go to Orders, any order<br>* Return a product<br>* **Before this PR**<br>![image](https://user-images.githubusercontent.com/1533248/159678729-009b2291-759b-4785-93f6-9566f09510b2.png)<br><br>* **After this PR**<br>![image](https://user-images.githubusercontent.com/1533248/159678496-17bf7ca9-ced4-4e2e-b794-d17f82a12e6e.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
