### PR TITLE
Fix deprecated CHARSET utf8 in Install and Upgrade

### DIFF
--- a/classes/Database/Install.php
+++ b/classes/Database/Install.php
@@ -61,14 +61,14 @@ class Install
             PRIMARY KEY (`id_google_analytics`),
             KEY `id_order` (`id_order`),
             KEY `sent` (`sent`)
-        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8 AUTO_INCREMENT=1';
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=1';
 
         $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'ganalytics_data` (
             `id_cart` int(11) NOT NULL,
             `id_shop` int(11) NOT NULL,
             `data` TEXT DEFAULT NULL,
             PRIMARY KEY (`id_cart`)
-        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8';
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8mb4';
 
         foreach ($sql as $query) {
             if (!Db::getInstance()->execute($query)) {

--- a/upgrade/upgrade-4.1.3.php
+++ b/upgrade/upgrade-4.1.3.php
@@ -26,6 +26,7 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_4_1_3($object)
 {
-    return $object->unregisterHook('displayHome') 
-        && Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'ganalytics` CHARACTER SET = utf8mb4 COLLATE utf8mb4_general_ci;');
+    return $object->unregisterHook('displayHome')
+        && Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'ganalytics` CHARACTER SET = utf8mb4 COLLATE utf8mb4_general_ci;')
+        && Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'ganalytics_data` CHARACTER SET = utf8mb4 COLLATE utf8mb4_general_ci;');
 }

--- a/upgrade/upgrade-4.1.3.php
+++ b/upgrade/upgrade-4.1.3.php
@@ -26,5 +26,6 @@ if (!defined('_PS_VERSION_')) {
  */
 function upgrade_module_4_1_3($object)
 {
-    return $object->unregisterHook('displayHome');
+    return $object->unregisterHook('displayHome') 
+        && Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'ganalytics` CHARACTER SET = utf8mb4 COLLATE utf8mb4_general_ci;');
 }


### PR DESCRIPTION
![ps_analytics_deprecated_charset_utf8](https://user-images.githubusercontent.com/3759923/175755566-32dddf67-cc84-44a4-b059-c45c31abdfad.png)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | You should also be aware that the utf8mb3 character set is deprecated and you should expect it to be removed in a future MySQL release. Please use utf8mb4 instead.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#28857
| How to test?      | Check ganalytics and ganalytics_data tables before PR with phpmyadmin you will see Collation = ---
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
