### PR TITLE
Fix deprecated CHARSET utf8 made by previous installation

### DIFF
--- a/upgrade/upgrade-4.1.4.php
+++ b/upgrade/upgrade-4.1.4.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2020 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_1_4($object)
+{
+    return Db::getInstance()->execute('ALTER TABLE `' . _DB_PREFIX_ . 'ganalytics` CHARACTER SET = utf8mb4 COLLATE utf8mb4_general_ci;');
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | install script prior 4.1.3 version CREATE TABLE with deprecated CHARSET=utf8
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes [#28860](https://github.com/PrestaShop/PrestaShop/issues/28860)
| How to test?      | Check the above issue.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
