### PR TITLE
Display Cross-Domain confirmation only when Multistore Enabled

### DIFF
--- a/classes/Form/ConfigurationForm.php
+++ b/classes/Form/ConfigurationForm.php
@@ -204,6 +204,9 @@ class ConfigurationForm
      */
     public function treat()
     {
+        // Check if multistore is active
+        $is_multistore_active = Shop::isFeatureActive();        
+        
         $treatmentResult = '';
         $gaAccountId = Tools::getValue('GA_ACCOUNT_ID');
         $gaUserIdEnabled = Tools::getValue('GA_USERID_ENABLED');
@@ -223,9 +226,9 @@ class ConfigurationForm
             $treatmentResult .= $this->module->displayConfirmation($this->module->l('Settings for User ID updated successfully'));
         }
 
-        if (null !== $gaCrossdomainEnabled) {
+        if ($is_multistore_active) {
             Configuration::updateValue('GA_CROSSDOMAIN_ENABLED', (bool) $gaCrossdomainEnabled);
-            $treatmentResult .= $this->module->displayConfirmation($this->module->l('Settings for User ID updated successfully'));
+            $treatmentResult .= $this->module->displayConfirmation($this->module->l('Settings for Cross-Domain updated successfully'));
         }
 
         if (null !== $gaAnonymizeEnabled) {

--- a/classes/Form/ConfigurationForm.php
+++ b/classes/Form/ConfigurationForm.php
@@ -206,7 +206,7 @@ class ConfigurationForm
     {
         // Check if multistore is active
         $is_multistore_active = Shop::isFeatureActive();
-        
+
         $treatmentResult = '';
         $gaAccountId = Tools::getValue('GA_ACCOUNT_ID');
         $gaUserIdEnabled = Tools::getValue('GA_USERID_ENABLED');

--- a/classes/Form/ConfigurationForm.php
+++ b/classes/Form/ConfigurationForm.php
@@ -205,7 +205,7 @@ class ConfigurationForm
     public function treat()
     {
         // Check if multistore is active
-        $is_multistore_active = Shop::isFeatureActive();        
+        $is_multistore_active = Shop::isFeatureActive();
         
         $treatmentResult = '';
         $gaAccountId = Tools::getValue('GA_ACCOUNT_ID');


### PR DESCRIPTION
In `function treat` that process ConfigurationForm save at https://github.com/PrestaShop/ps_googleanalytics/blob/dev/classes/Form/ConfigurationForm.php#L205-L229
If `GA_CROSSDOMAIN_ENABLED` is not set, `Tools::getValue('GA_CROSSDOMAIN_ENABLED')` will return `False`, then `$gaCrossdomainEnabled` is assigned to `False`.
In turn `(null !== $gaCrossdomainEnabled)` is `True` because `(null !== False)` is `True`.
That's why ConfigurationForm Save display CrossDomain confirmation even when multistore is `Disabled`. Furthermore, CrossDomain setting reused UserIDTracking's Translation string, not its own.
![ps_googleanalytics_multishop_enabled](https://user-images.githubusercontent.com/3759923/176663633-daf9fa6c-fb6a-48ef-bb65-66b1afa13b42.png)
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Solution: calculate and use `$is_multistore_active` like `function generate `did at line 49 and 169, add a new Translation string also. 
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop/issues/28005
| How to test?      | After this PR, with multistore `Disabled` the wrong confirmation described in issue 28005 will disappear, with multistore `Enabled` and more than 1 shop the right confirmation will display like above screenshot.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
