### PR TITLE
Fix carrier name quote error in JS

### DIFF
--- a/classes/Hook/HookActionCarrierProcess.php
+++ b/classes/Hook/HookActionCarrierProcess.php
@@ -52,7 +52,7 @@ class HookActionCarrierProcess implements HookInterface
             );
 
             $carrierName = $carrierRepository->findByCarrierId((int) $this->params['cart']->id_carrier);
-            $ganalyticsDataHandler->manageData('MBG.addCheckoutOption(2,\'' . $carrierName . '\');', 'A');
+            $ganalyticsDataHandler->manageData('MBG.addCheckoutOption(2,\'' . addslashes($carrierName) . '\');', 'A');
         }
     }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/102657707/188402755-06ff25ea-f808-48ae-8516-1fb0ac518d90.png)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixing js command line generated in this class for carrier name with coma, to avoid js error
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29522
| How to test?      | Use a carrier name like this one "Retrait à l'usine", when front user arrived to order'final step, in the console js you'll get the "Syntax error, missing ) after argument list (at commande?step=3)"
| Possible impacts? | Js not interpreted

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
