### PR TITLE
GA4 : set debug mode to off

### DIFF
--- a/views/templates/hook/ps_googleanalytics.tpl
+++ b/views/templates/hook/ps_googleanalytics.tpl
@@ -27,7 +27,7 @@
       'config',
       '{$gaAccountId|escape:'htmlall':'UTF-8'}',
       {ldelim}
-        'debug_mode':true
+        'debug_mode':false
         {if $gaAnonymizeEnabled}, 'anonymize_ip': true{/if}
         {if $userId && !$backOffice}, 'user_id': '{$userId|escape:'htmlall':'UTF-8'}'{/if}
         {if $backOffice && !$trackBackOffice}, 'non_interaction': true, 'send_page_view': false{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Debug mode in GA4 can be set with a chrome extension or GTM, it doesn't have to be activated by default.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  (https://github.com/PrestaShop/ps_googleanalytics/pull/131#discussion_r1136020752)
| Sponsor company   | Creabilis.
| How to test?      | Check that debug mode is of in Google Analytics bo
