### PR TITLE
Remove usage of deprecated method ajaxDie

### DIFF
--- a/controllers/admin/AdminGanalyticsAjax.php
+++ b/controllers/admin/AdminGanalyticsAjax.php
@@ -32,8 +32,10 @@ class AdminGanalyticsAjaxController extends ModuleAdminController
         if (Validate::isLoadedObject($order) && (isset($this->context->employee->id) && $this->context->employee->id)) {
             (new GanalyticsRepository())->markOrderAsSent((int) $orderId);
             $this->ajaxRender('OK');
+            exit;
         }
 
         $this->ajaxRender('KO');
+        exit;
     }
 }

--- a/controllers/admin/AdminGanalyticsAjax.php
+++ b/controllers/admin/AdminGanalyticsAjax.php
@@ -31,9 +31,9 @@ class AdminGanalyticsAjaxController extends ModuleAdminController
 
         if (Validate::isLoadedObject($order) && (isset($this->context->employee->id) && $this->context->employee->id)) {
             (new GanalyticsRepository())->markOrderAsSent((int) $orderId);
-            $this->ajaxDie('OK');
+            $this->ajaxRender('OK');
         }
 
-        $this->ajaxDie('KO');
+        $this->ajaxRender('KO');
     }
 }

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -35,11 +35,11 @@ class ps_GoogleanalyticsAjaxModuleFrontController extends ModuleFrontController
         $order = new Order($orderId);
 
         if (!Validate::isLoadedObject($order) || $order->id_customer != (int) Tools::getValue('customer')) {
-            $this->ajaxDie('KO');
+            $this->ajaxRender('KO');
         }
 
         (new GanalyticsRepository())->markOrderAsSent((int) $orderId);
 
-        $this->ajaxDie('OK');
+        $this->ajaxRender('OK');
     }
 }

--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -36,10 +36,12 @@ class ps_GoogleanalyticsAjaxModuleFrontController extends ModuleFrontController
 
         if (!Validate::isLoadedObject($order) || $order->id_customer != (int) Tools::getValue('customer')) {
             $this->ajaxRender('KO');
+            exit;
         }
 
         (new GanalyticsRepository())->markOrderAsSent((int) $orderId);
 
         $this->ajaxRender('OK');
+        exit;
     }
 }

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -6,3 +6,4 @@ parameters:
 		- '#PrestaShop\\Module\\Ps_Googleanalytics\\Handler\\ModuleHandler::uninstallModule\(\) calls parent::uninstall\(\) but PrestaShop\\Module\\Ps_Googleanalytics\\Handler\\ModuleHandler does not extend any class.#'
 		- '#Access to an undefined property Cookie\:\:\$ga_admin_order.#'
 		- '#Access to an undefined property Cookie\:\:\$ga_admin_refund.#'
+		- '#Parameter \#1 \$value of method ControllerCore::ajaxRender\(\) expects null, string given.#'


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | ajaxDie is deprecated and ajaxRender should be used instead. Related to https://github.com/PrestaShop/PrestaShop/pull/35283.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      |
