### PR TITLE
Fix bug breaking price cache keys used in getPriceStatic and priceCalculation

### DIFF
--- a/classes/Hook/HookActionCartUpdateQuantityBefore.php
+++ b/classes/Hook/HookActionCartUpdateQuantityBefore.php
@@ -66,15 +66,13 @@ class HookActionCartUpdateQuantityBefore implements HookInterface
         // Format product and standardize ID
         $product = (array) $this->params['product'];
         $product['id_product'] = $product['id'];
-        $product['id_product_attribute'] = $this->params['id_product_attribute'];
-
-        // Get some basic information
-        $product = Product::getProductProperties($this->context->language->id, $product);
-
         // Add information about attribute
         if (!empty($this->params['id_product_attribute'])) {
             $product['id_product_attribute'] = (int) $this->params['id_product_attribute'];
         }
+
+        // Get some basic information
+        $product = Product::getProductProperties($this->context->language->id, $product);
 
         // Add information about quantity difference
         $product['quantity'] = (int) $this->params['quantity'];

--- a/classes/Hook/HookActionCartUpdateQuantityBefore.php
+++ b/classes/Hook/HookActionCartUpdateQuantityBefore.php
@@ -66,6 +66,7 @@ class HookActionCartUpdateQuantityBefore implements HookInterface
         // Format product and standardize ID
         $product = (array) $this->params['product'];
         $product['id_product'] = $product['id'];
+        $product['id_product_attribute'] = $this->params['id_product_attribute'];
 
         // Get some basic information
         $product = Product::getProductProperties($this->context->language->id, $product);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The method `getProductProperties` was sent a product without an `id_product_attribute` specified, which caused a price cache key to not be build properly
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | PrestaShop SA
| How to test?      | 