### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/classes/Hook/HookDisplayBackOfficeHeader.php
+++ b/classes/Hook/HookDisplayBackOfficeHeader.php
@@ -89,7 +89,7 @@ class HookDisplayBackOfficeHeader implements HookInterface
         $failedOrders = Db::getInstance()->ExecuteS(
             'SELECT DISTINCT o.id_order, g.sent FROM `' . _DB_PREFIX_ . 'orders` o
             LEFT JOIN `' . _DB_PREFIX_ . GanalyticsRepository::TABLE_NAME . '` g ON o.id_order = g.id_order
-            WHERE (g.sent IS NULL OR g.sent = 0) AND o.date_add BETWEEN NOW() - INTERVAL ' . $backloadDays . ' DAY AND NOW() - INTERVAL 30 MINUTE'
+            WHERE (g.sent IS NULL OR g.sent = 0) AND o.date_add BETWEEN \'' . date('Y-m-d H:i:s', strtotime('-' . $backloadDays . ' days')) . '\' AND \'' . date('Y-m-d H:i:s', strtotime('-30 minutes')) . '\''
         );
 
         // Process each failed order

--- a/classes/Repository/GanalyticsRepository.php
+++ b/classes/Repository/GanalyticsRepository.php
@@ -70,7 +70,7 @@ class GanalyticsRepository
             FROM `' . _DB_PREFIX_ . self::TABLE_NAME . '`
             WHERE sent = 0
                 AND id_shop = ' . (int) $shopId . '
-                AND DATE_ADD(date_add, INTERVAL 30 minute) < NOW()'
+                AND DATE_ADD(date_add, INTERVAL 30 minute) < \'' . date('Y-m-d H:i:s') . '\''
         );
     }
 
@@ -108,7 +108,7 @@ class GanalyticsRepository
                 'id_order' => (int) $idOrder,
                 'id_shop' => (int) $idShop,
                 'sent' => 0,
-                'date_add' => ['value' => 'NOW()', 'type' => 'sql'],
+                'date_add' => date('Y-m-d H:i:s'),
             ]
         );
     }
@@ -144,7 +144,7 @@ class GanalyticsRepository
         return Db::getInstance()->update(
             self::TABLE_NAME,
             [
-                'date_add' => ['value' => 'NOW()', 'type' => 'sql'],
+                'date_add' => date('Y-m-d H:i:s'),
                 'sent' => 1,
             ],
             'id_order = ' . (int) $idOrder


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Several SQL queries used \`NOW()\` which relies on the MySQL server timezone (UTC by default), instead of the shop's configured timezone (PHP). This could cause incorrect behavior when the shop timezone differs from the MySQL server timezone.<br/><br/>Changes:<br/>- \`GanalyticsRepository::findAllByShopIdAndDateAdd()\`: \`DATE_ADD(date_add, ...) < NOW()\` replaced with a PHP-computed datetime string<br/>- \`GanalyticsRepository::addOrder()\` and \`markOrderAsSent()\`: \`NOW()\` SQL value replaced with \`date('Y-m-d H:i:s')\`<br/>- \`HookDisplayBackOfficeHeader\`: \`BETWEEN NOW() - INTERVAL x DAY AND NOW() - INTERVAL 30 MINUTE\` replaced with PHP-computed interval boundaries
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Related to PrestaShop/PrestaShop#30828
| Related PRs       | PrestaShop/PrestaShop#41596
| Sponsor company   | PrestaShop SA