### PR TITLE
Prevent fatal error when product template variable is a Product object

### DIFF
--- a/classes/Hook/HookDisplayFooterProduct.php
+++ b/classes/Hook/HookDisplayFooterProduct.php
@@ -54,6 +54,14 @@ class HookDisplayFooterProduct implements HookInterface
             return;
         }
 
+        // The 'product' template variable is expected to be a ProductLazyArray (array-accessible).
+        // Some themes or modules assign a raw Product object instead, which prepareItemFromProduct()
+        // cannot consume (it accesses array keys) and would raise a fatal error on the product page.
+        // Skip tracking in that case rather than breaking the page.
+        if (!is_array($product) && !$product instanceof \ArrayAccess) {
+            return;
+        }
+
         // Initialize tag handler
         $gaTagHandler = new GanalyticsJsHandler($this->module, $this->context);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `HookDisplayFooterProduct::run()` reads the `product` Smarty variable and passes it straight to `ProductWrapper::prepareItemFromProduct()`, which consumes it with array keys (`$product['id_product']`, `$product['name']`, …). That variable is normally a `ProductLazyArray` (array-accessible), but some themes/modules assign a **raw `Product` object** to it, producing a fatal error `Cannot use object of type Product as array` on the product page (reported on 5.0.3 / PS 8.2.4). This PR guards the hook: if the product is not array-accessible, it skips tracking instead of breaking the page. `ProductLazyArray` implements `ArrayAccess`, so the normal flow is unaffected.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/ps_googleanalytics#179.
| How to test?      | On a product page where the `product` Smarty variable is a raw `Product` object, before this PR the page fatals with `Cannot use object of type Product as array` (`ProductWrapper.php` line ~136). Deterministic check: `prepareItemFromProduct(new Product(1))` throws that error; with the guard, `HookDisplayFooterProduct::run()` returns without a fatal. With the standard `ProductLazyArray` (which implements `ArrayAccess`), tracking continues to work as before.
| Sponsor company   |
