### PR TITLE
Remove the stale compatibility sentence from the README contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Enhanced Ecommerce must be enabled in Google Analytics settings for full functio
 
 PrestaShop modules are open-source extensions to the PrestaShop e-commerce solution. Everyone is welcome and even encouraged to contribute with their own improvements.
 
-Google Analytics is compatible with PrestaShop 1.7.7 and newer.
-
 ### Requirements
 
 Contributors **must** follow the following rules:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | The README contradicts itself: the `Compatibility` section correctly says `8.2.0` or later, while a leftover line further down, in the middle of the contributing rules, still claims compatibility with PrestaShop 1.7.7 and newer. That line is both wrong and misplaced, a compatibility statement does not belong in the contributing section, so it is removed rather than corrected.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#41648
| How to test?      | Documentation only, nothing to test.
| Sponsor company   | @PrestaShopCorp
