### PR TITLE
Fix redundant array check in purchase event

### DIFF
--- a/classes/GoogleAnalyticsTools.php
+++ b/classes/GoogleAnalyticsTools.php
@@ -31,10 +31,13 @@ class GoogleAnalyticsTools
      * @param array $orderData
      * @param string $callbackUrl
      *
-     * @return string|void
+     * @return string
      */
-    public function renderPurchaseEvent($orderProducts, $orderData, $callbackUrl)
-    {
+    public function renderPurchaseEvent(
+        array $orderProducts,
+        array $orderData,
+        string $callbackUrl
+    ): string {
         $callbackData = [
             'orderid' => $orderData['transaction_id'],
             'customer' => $orderData['customer'],
@@ -68,8 +71,10 @@ class GoogleAnalyticsTools
      *
      * @return string json encoded data
      */
-    public function jsonEncodeWithBlacklist($data, $ignoredKeys = [])
-    {
+    public function jsonEncodeWithBlacklist(
+        array $data,
+        array $ignoredKeys = []
+    ): string {
         $return = [];
 
         foreach ($data as $k => $v) {
@@ -93,8 +98,11 @@ class GoogleAnalyticsTools
      *
      * @return string render gtag event for output
      */
-    public function renderEvent($eventName, $eventData, $ignoredKeys = [])
-    {
+    public function renderEvent(
+        string $eventName,
+        array $eventData,
+        array $ignoredKeys = []
+    ): string {
         // Automatically add send_to parameter to all events to avoid sending extra events
         // to other gtag configs (Ads for example).
         $eventData = array_merge(

--- a/classes/GoogleAnalyticsTools.php
+++ b/classes/GoogleAnalyticsTools.php
@@ -35,10 +35,6 @@ class GoogleAnalyticsTools
      */
     public function renderPurchaseEvent($orderProducts, $orderData, $callbackUrl)
     {
-        if (!is_array($orderProducts)) {
-            return;
-        }
-
         $callbackData = [
             'orderid' => $orderData['transaction_id'],
             'customer' => $orderData['customer'],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR removes a redundant `is_array()` check in `GoogleAnalyticsTools::renderPurchaseEvent()`.<br><br>`$orderProducts` is already declared as an `array` in the method PHPDoc, so PHPStan correctly reports:<br><br>`Call to function is_array() with array will always evaluate to true.`<br><br>The issue is reproducible directly on the current `dev` branch and is unrelated to any functional change.<br><br>
| Type?             | bug fix
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | F
| Related to | https://github.com/PrestaShop/ps_googleanalytics/pull/170#issuecomment-5557610677
| Sponsor company   | Codencode snc 
| How to test?      | Run the PHPStan checks and verify that the `develop` job passes without reporting: `Call to function is_array() with array will always evaluate to true.`
